### PR TITLE
Fix the calculation of renames in the delta tree adapter.

### DIFF
--- a/coderadar-core/build.gradle
+++ b/coderadar-core/build.gradle
@@ -9,6 +9,8 @@ dependencies {
     compile "com.auth0:java-jwt:3.1.0"
     compile "joda-time:joda-time:2.9.7"
     compile "org.springframework.boot:spring-boot-starter-web:${version_spring_boot}"
+    compile "org.springframework.data:spring-data-commons:${version_spring_boot}"
+
     compile "org.springframework.boot:spring-boot-starter-security:${version_spring_boot}"
     compile "io.dropwizard:dropwizard-metrics:1.0.6"
     compile group: 'io.dropwizard.metrics', name: 'metrics-annotation', version: '3.2.1'
@@ -16,7 +18,6 @@ dependencies {
     compile "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.9.8"
     compile group: 'org.reflections', name: 'reflections', version: '0.9.11'
     testCompile "org.springframework.boot:spring-boot-starter-test:${version_spring_boot}"
-    compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.11'
 }
 
 spotless {

--- a/coderadar-core/build.gradle
+++ b/coderadar-core/build.gradle
@@ -16,6 +16,7 @@ dependencies {
     compile "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.9.8"
     compile group: 'org.reflections', name: 'reflections', version: '0.9.11'
     testCompile "org.springframework.boot:spring-boot-starter-test:${version_spring_boot}"
+    compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.11'
 }
 
 spotless {

--- a/coderadar-core/src/main/java/io/reflectoring/coderadar/projectadministration/domain/File.java
+++ b/coderadar-core/src/main/java/io/reflectoring/coderadar/projectadministration/domain/File.java
@@ -14,7 +14,6 @@ public class File {
   private long id;
   private String path;
   private long sequenceId;
-  private String objectHash;
 
   @EqualsAndHashCode.Exclude private List<File> oldFiles = Collections.emptyList();
 }

--- a/coderadar-core/src/main/java/io/reflectoring/coderadar/vcs/port/driven/GetRawCommitContentPort.java
+++ b/coderadar-core/src/main/java/io/reflectoring/coderadar/vcs/port/driven/GetRawCommitContentPort.java
@@ -56,5 +56,13 @@ public interface GetRawCommitContentPort {
           String commitHash)
           throws UnableToGetCommitContentException;
 
-  List<Pair<String, String>> findRenames(String parentHash, String commitHash, String projectRoot);
+  /**
+   * @param parentHash The first commit hash.
+   * @param commitHash The second commit hash.
+   * @param projectRoot The local repository.
+   * @return A list of String pairs, where the left element is the old path and the right one is the
+   *     new path.
+   */
+  List<Pair<String, String>> getRenamesBetweenCommits(
+      String parentHash, String commitHash, String projectRoot);
 }

--- a/coderadar-core/src/main/java/io/reflectoring/coderadar/vcs/port/driven/GetRawCommitContentPort.java
+++ b/coderadar-core/src/main/java/io/reflectoring/coderadar/vcs/port/driven/GetRawCommitContentPort.java
@@ -3,7 +3,7 @@ package io.reflectoring.coderadar.vcs.port.driven;
 import io.reflectoring.coderadar.vcs.UnableToGetCommitContentException;
 import java.util.HashMap;
 import java.util.List;
-import org.apache.commons.lang3.tuple.Pair;
+import org.springframework.data.util.Pair;
 
 public interface GetRawCommitContentPort {
 

--- a/coderadar-core/src/main/java/io/reflectoring/coderadar/vcs/port/driven/GetRawCommitContentPort.java
+++ b/coderadar-core/src/main/java/io/reflectoring/coderadar/vcs/port/driven/GetRawCommitContentPort.java
@@ -3,6 +3,7 @@ package io.reflectoring.coderadar.vcs.port.driven;
 import io.reflectoring.coderadar.vcs.UnableToGetCommitContentException;
 import java.util.HashMap;
 import java.util.List;
+import org.apache.commons.lang3.tuple.Pair;
 
 public interface GetRawCommitContentPort {
 
@@ -54,4 +55,6 @@ public interface GetRawCommitContentPort {
           List<io.reflectoring.coderadar.projectadministration.domain.File> files,
           String commitHash)
           throws UnableToGetCommitContentException;
+
+  List<Pair<String, String>> findRenames(String parentHash, String commitHash, String projectRoot);
 }

--- a/coderadar-graph/src/main/java/io/reflectoring/coderadar/graph/projectadministration/domain/FileEntity.java
+++ b/coderadar-graph/src/main/java/io/reflectoring/coderadar/graph/projectadministration/domain/FileEntity.java
@@ -15,7 +15,6 @@ public class FileEntity {
   private Long id;
   private String path;
   private long sequenceId;
-  private String objectHash;
 
   @EqualsAndHashCode.Exclude
   @Relationship(type = "RENAMED_FROM")

--- a/coderadar-graph/src/main/java/io/reflectoring/coderadar/graph/projectadministration/project/adapter/FileBaseDataMapper.java
+++ b/coderadar-graph/src/main/java/io/reflectoring/coderadar/graph/projectadministration/project/adapter/FileBaseDataMapper.java
@@ -11,7 +11,6 @@ public class FileBaseDataMapper implements Mapper<File, FileEntity> {
     file.setId(entity.getId());
     file.setPath(entity.getPath());
     file.setSequenceId(entity.getSequenceId());
-    file.setObjectHash(entity.getObjectHash());
     return file;
   }
 
@@ -19,7 +18,6 @@ public class FileBaseDataMapper implements Mapper<File, FileEntity> {
     FileEntity fileEntity = new FileEntity();
     fileEntity.setPath(file.getPath());
     fileEntity.setSequenceId(file.getSequenceId());
-    fileEntity.setObjectHash(file.getObjectHash());
     return fileEntity;
   }
 }

--- a/coderadar-graph/src/main/java/io/reflectoring/coderadar/graph/query/adapter/GetDeltaTreeForTwoCommitsAdapter.java
+++ b/coderadar-graph/src/main/java/io/reflectoring/coderadar/graph/query/adapter/GetDeltaTreeForTwoCommitsAdapter.java
@@ -59,7 +59,7 @@ public class GetDeltaTreeForTwoCommitsAdapter implements GetDeltaTreeForTwoCommi
 
     DeltaTree deltaTree = createDeltaTree(commit1Tree, commit2Tree);
     List<Pair<String, String>> renamedFiles =
-        getRawCommitContentPort.findRenames(
+        getRawCommitContentPort.getRenamesBetweenCommits(
             command.getCommit1(),
             command.getCommit2(),
             coderadarConfigurationProperties.getWorkdir()
@@ -145,10 +145,7 @@ public class GetDeltaTreeForTwoCommitsAdapter implements GetDeltaTreeForTwoCommi
   private ChangeType getChangeType(MetricTree metricTree1, MetricTree metricTree2) {
     if (metricTree1 != null
         && metricTree2 != null
-        && metricTree1
-            .getName()
-            .split("=")[0]
-            .equals(metricTree2.getName().split("=")[0])) { // File exists in both trees
+        && metricTree1.getName().equals(metricTree2.getName())) { // File exists in both trees
       return ChangeType.MODIFY;
     } else if (metricTree1 != null // File deleted in new tree
         && (metricTree2 == null || metricTree1.getName().compareTo(metricTree2.getName()) < 0)) {

--- a/coderadar-graph/src/main/java/io/reflectoring/coderadar/graph/query/adapter/GetDeltaTreeForTwoCommitsAdapter.java
+++ b/coderadar-graph/src/main/java/io/reflectoring/coderadar/graph/query/adapter/GetDeltaTreeForTwoCommitsAdapter.java
@@ -1,5 +1,6 @@
 package io.reflectoring.coderadar.graph.query.adapter;
 
+import io.reflectoring.coderadar.CoderadarConfigurationProperties;
 import io.reflectoring.coderadar.graph.analyzer.repository.CommitRepository;
 import io.reflectoring.coderadar.graph.projectadministration.domain.ProjectEntity;
 import io.reflectoring.coderadar.graph.projectadministration.project.repository.ProjectRepository;
@@ -8,8 +9,10 @@ import io.reflectoring.coderadar.projectadministration.ProjectNotFoundException;
 import io.reflectoring.coderadar.query.domain.*;
 import io.reflectoring.coderadar.query.port.driven.GetDeltaTreeForTwoCommitsPort;
 import io.reflectoring.coderadar.query.port.driver.deltatree.GetDeltaTreeForTwoCommitsCommand;
+import io.reflectoring.coderadar.vcs.port.driven.GetRawCommitContentPort;
 import java.util.ArrayList;
 import java.util.List;
+import org.apache.commons.lang3.tuple.Pair;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -18,14 +21,20 @@ public class GetDeltaTreeForTwoCommitsAdapter implements GetDeltaTreeForTwoCommi
   private final GetMetricTreeForCommitAdapter getMetricsForAllFilesInCommitAdapter;
   private final ProjectRepository projectRepository;
   private final CommitRepository commitRepository;
+  private final GetRawCommitContentPort getRawCommitContentPort;
+  private final CoderadarConfigurationProperties coderadarConfigurationProperties;
 
   public GetDeltaTreeForTwoCommitsAdapter(
       GetMetricTreeForCommitAdapter getMetricsForAllFilesInCommitAdapter,
       ProjectRepository projectRepository,
-      CommitRepository commitRepository) {
+      CommitRepository commitRepository,
+      GetRawCommitContentPort getRawCommitContentPort,
+      CoderadarConfigurationProperties coderadarConfigurationProperties) {
     this.getMetricsForAllFilesInCommitAdapter = getMetricsForAllFilesInCommitAdapter;
     this.projectRepository = projectRepository;
     this.commitRepository = commitRepository;
+    this.getRawCommitContentPort = getRawCommitContentPort;
+    this.coderadarConfigurationProperties = coderadarConfigurationProperties;
   }
 
   @Override
@@ -43,55 +52,38 @@ public class GetDeltaTreeForTwoCommitsAdapter implements GetDeltaTreeForTwoCommi
 
     MetricTree commit1Tree =
         getMetricsForAllFilesInCommitAdapter.get(
-            projectEntity, command.getCommit1(), command.getMetrics(), true);
+            projectEntity, command.getCommit1(), command.getMetrics());
     MetricTree commit2Tree =
         getMetricsForAllFilesInCommitAdapter.get(
-            projectEntity, command.getCommit2(), command.getMetrics(), true);
+            projectEntity, command.getCommit2(), command.getMetrics());
 
-    List<String> addedFiles = new ArrayList<>();
-    List<String> removedFiles = new ArrayList<>();
-
-    DeltaTree deltaTree = createDeltaTree(commit1Tree, commit2Tree, addedFiles, removedFiles);
-    processRenames(deltaTree, removedFiles, addedFiles);
-    trimHashesFromTree(deltaTree);
+    DeltaTree deltaTree = createDeltaTree(commit1Tree, commit2Tree);
+    List<Pair<String, String>> renamedFiles =
+        getRawCommitContentPort.findRenames(
+            command.getCommit1(),
+            command.getCommit2(),
+            coderadarConfigurationProperties.getWorkdir()
+                + "/projects/"
+                + projectEntity.getWorkdirName());
+    processRenames(deltaTree, renamedFiles);
     return deltaTree;
   }
 
-  private void trimHashesFromTree(DeltaTree deltaTree) {
-    if (deltaTree.getType().equals(MetricTreeNodeType.FILE)) {
-      deltaTree.setName(deltaTree.getName().split("=")[0]);
-    }
-    if (!deltaTree.getChildren().isEmpty()) {
-      deltaTree.getChildren().forEach(this::trimHashesFromTree);
-    }
-  }
+  private void processRenames(DeltaTree deltaTree, List<Pair<String, String>> renamedFiles) {
 
-  private void processRenames(
-      DeltaTree deltaTree, List<String> removedFiles, List<String> addedFiles) {
+    for (Pair<String, String> rename : renamedFiles) {
+      DeltaTree oldEntry = findChildInDeltaTree(deltaTree, rename.getLeft());
+      DeltaTree newEntry = findChildInDeltaTree(deltaTree, rename.getRight());
+      if (oldEntry != null && newEntry != null) {
+        newEntry.setCommit1Metrics(oldEntry.getCommit1Metrics());
 
-    for (String addedFile : addedFiles) {
-      String newHash = addedFile.split("=")[1];
+        newEntry.getChanges().setAdded(false);
+        newEntry.getChanges().setRenamed(true);
+        newEntry.setRenamedFrom(rename.getLeft());
 
-      for (int i = 0; i < removedFiles.size(); ++i) {
-        String removedFile = removedFiles.get(i);
-        String oldHash = removedFile.split("=")[1];
-        if (oldHash.equals(newHash)) {
-          DeltaTree oldEntry = findChildInDeltaTree(deltaTree, removedFile);
-          DeltaTree newEntry = findChildInDeltaTree(deltaTree, addedFile);
-          if (oldEntry != null && newEntry != null) {
-            newEntry.setCommit1Metrics(oldEntry.getCommit1Metrics());
-
-            newEntry.getChanges().setAdded(false);
-            newEntry.getChanges().setRenamed(true);
-            newEntry.setRenamedFrom(removedFile.split("=")[0]);
-
-            oldEntry.getChanges().setRenamed(true);
-            oldEntry.getChanges().setDeleted(false);
-            oldEntry.setRenamedTo(addedFile.split("=")[0]);
-            removedFiles.remove(removedFile);
-            break;
-          }
-        }
+        oldEntry.getChanges().setRenamed(true);
+        oldEntry.getChanges().setDeleted(false);
+        oldEntry.setRenamedTo(rename.getRight());
       }
     }
   }
@@ -101,16 +93,10 @@ public class GetDeltaTreeForTwoCommitsAdapter implements GetDeltaTreeForTwoCommi
    *
    * @param commit1Tree The metric tree of the first commit.
    * @param commit2Tree The metric tree of the second commit.
-   * @param addedFiles A list, that must be filled with all files added in the newest commit.
-   * @param removedFiles A list, that must be filled with all files removed in the newest commit.
    * @return A delta tree, which contains no information about renames. Renames must be processed
    *     separately using the added and removed files lists.
    */
-  private DeltaTree createDeltaTree(
-      MetricTree commit1Tree,
-      MetricTree commit2Tree,
-      List<String> addedFiles,
-      List<String> removedFiles) {
+  private DeltaTree createDeltaTree(MetricTree commit1Tree, MetricTree commit2Tree) {
     DeltaTree deltaTree = new DeltaTree();
     deltaTree.setName(commit2Tree.getName());
     deltaTree.setType(commit2Tree.getType());
@@ -134,9 +120,7 @@ public class GetDeltaTreeForTwoCommitsAdapter implements GetDeltaTreeForTwoCommi
       if (getChangeType(metricTree1, metricTree2).equals(ChangeType.MODIFY)) {
         if (metricTree1.getType().equals(MetricTreeNodeType.MODULE)
             && metricTree2.getType().equals(MetricTreeNodeType.MODULE)) {
-          deltaTree
-              .getChildren()
-              .add(createDeltaTree(metricTree1, metricTree2, addedFiles, removedFiles));
+          deltaTree.getChildren().add(createDeltaTree(metricTree1, metricTree2));
         } else {
           deltaTree.getChildren().add(createFileNode(metricTree1, metricTree2));
         }
@@ -144,16 +128,13 @@ public class GetDeltaTreeForTwoCommitsAdapter implements GetDeltaTreeForTwoCommi
         tree2Counter++;
       } else if (getChangeType(metricTree1, metricTree2).equals(ChangeType.DELETE)) {
         deltaTree.getChildren().add(createDeletedFileNode(metricTree1));
-        removedFiles.add(metricTree1.getName());
         tree1Counter++;
       } else {
         if (metricTree2.getType().equals(MetricTreeNodeType.MODULE) && metricTree1 != null) {
           deltaTree.getChildren().add(createAddedFileNode(metricTree1));
-          addedFiles.add(metricTree1.getName());
           tree1Counter++;
         } else {
           deltaTree.getChildren().add(createAddedFileNode(metricTree2));
-          addedFiles.add(metricTree2.getName());
           tree2Counter++;
         }
       }

--- a/coderadar-graph/src/main/java/io/reflectoring/coderadar/graph/query/adapter/GetDeltaTreeForTwoCommitsAdapter.java
+++ b/coderadar-graph/src/main/java/io/reflectoring/coderadar/graph/query/adapter/GetDeltaTreeForTwoCommitsAdapter.java
@@ -12,7 +12,7 @@ import io.reflectoring.coderadar.query.port.driver.deltatree.GetDeltaTreeForTwoC
 import io.reflectoring.coderadar.vcs.port.driven.GetRawCommitContentPort;
 import java.util.ArrayList;
 import java.util.List;
-import org.apache.commons.lang3.tuple.Pair;
+import org.springframework.data.util.Pair;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -72,18 +72,18 @@ public class GetDeltaTreeForTwoCommitsAdapter implements GetDeltaTreeForTwoCommi
   private void processRenames(DeltaTree deltaTree, List<Pair<String, String>> renamedFiles) {
 
     for (Pair<String, String> rename : renamedFiles) {
-      DeltaTree oldEntry = findChildInDeltaTree(deltaTree, rename.getLeft());
-      DeltaTree newEntry = findChildInDeltaTree(deltaTree, rename.getRight());
+      DeltaTree oldEntry = findChildInDeltaTree(deltaTree, rename.getFirst());
+      DeltaTree newEntry = findChildInDeltaTree(deltaTree, rename.getSecond());
       if (oldEntry != null && newEntry != null) {
         newEntry.setCommit1Metrics(oldEntry.getCommit1Metrics());
 
         newEntry.getChanges().setAdded(false);
         newEntry.getChanges().setRenamed(true);
-        newEntry.setRenamedFrom(rename.getLeft());
+        newEntry.setRenamedFrom(rename.getFirst());
 
         oldEntry.getChanges().setRenamed(true);
         oldEntry.getChanges().setDeleted(false);
-        oldEntry.setRenamedTo(rename.getRight());
+        oldEntry.setRenamedTo(rename.getSecond());
       }
     }
   }

--- a/coderadar-graph/src/main/java/io/reflectoring/coderadar/graph/query/adapter/GetMetricTreeForCommitAdapter.java
+++ b/coderadar-graph/src/main/java/io/reflectoring/coderadar/graph/query/adapter/GetMetricTreeForCommitAdapter.java
@@ -33,18 +33,10 @@ public class GetMetricTreeForCommitAdapter implements GetMetricTreeForCommitPort
     this.moduleRepository = moduleRepository;
   }
 
-  MetricTree get(
-      ProjectEntity project, String commitHash, List<String> metrics, boolean includeFileHashes) {
-    List<Map<String, Object>> result;
-    if (includeFileHashes) {
-      result =
-          metricQueryRepository.getMetricTreeForCommitWithFileHashes(
-              project.getId(), commitHash, metrics);
-    } else {
-      result = metricQueryRepository.getMetricTreeForCommit(project.getId(), commitHash, metrics);
-    }
-    List<ModuleEntity> moduleEntities = // project already has the modules??
-        moduleRepository.findModulesInProjectSortedDesc(project.getId());
+  MetricTree get(ProjectEntity project, String commitHash, List<String> metrics) {
+    List<Map<String, Object>> result =
+        metricQueryRepository.getMetricTreeForCommit(project.getId(), commitHash, metrics);
+    List<ModuleEntity> moduleEntities = project.getModules();
     List<MetricTree> moduleChildren = processModules(moduleEntities, result);
     MetricTree rootModule = processRootModule(result);
     rootModule.getChildren().addAll(findChildModules(project.getModules(), moduleChildren));
@@ -58,7 +50,7 @@ public class GetMetricTreeForCommitAdapter implements GetMetricTreeForCommitPort
         projectRepository
             .findByIdWithModules(projectId)
             .orElseThrow(() -> new ProjectNotFoundException(projectId));
-    return get(projectEntity, command.getCommit(), command.getMetrics(), false);
+    return get(projectEntity, command.getCommit(), command.getMetrics());
   }
 
   /**

--- a/coderadar-graph/src/main/java/io/reflectoring/coderadar/graph/query/adapter/GetMetricTreeForCommitAdapter.java
+++ b/coderadar-graph/src/main/java/io/reflectoring/coderadar/graph/query/adapter/GetMetricTreeForCommitAdapter.java
@@ -2,7 +2,6 @@ package io.reflectoring.coderadar.graph.query.adapter;
 
 import io.reflectoring.coderadar.graph.projectadministration.domain.ModuleEntity;
 import io.reflectoring.coderadar.graph.projectadministration.domain.ProjectEntity;
-import io.reflectoring.coderadar.graph.projectadministration.module.repository.ModuleRepository;
 import io.reflectoring.coderadar.graph.projectadministration.project.repository.ProjectRepository;
 import io.reflectoring.coderadar.graph.query.repository.MetricQueryRepository;
 import io.reflectoring.coderadar.projectadministration.ProjectNotFoundException;
@@ -22,15 +21,11 @@ public class GetMetricTreeForCommitAdapter implements GetMetricTreeForCommitPort
 
   private final MetricQueryRepository metricQueryRepository;
   private final ProjectRepository projectRepository;
-  private final ModuleRepository moduleRepository;
 
   public GetMetricTreeForCommitAdapter(
-      MetricQueryRepository metricQueryRepository,
-      ProjectRepository projectRepository,
-      ModuleRepository moduleRepository) {
+      MetricQueryRepository metricQueryRepository, ProjectRepository projectRepository) {
     this.metricQueryRepository = metricQueryRepository;
     this.projectRepository = projectRepository;
-    this.moduleRepository = moduleRepository;
   }
 
   MetricTree get(ProjectEntity project, String commitHash, List<String> metrics) {

--- a/coderadar-graph/src/main/java/io/reflectoring/coderadar/graph/query/repository/MetricQueryRepository.java
+++ b/coderadar-graph/src/main/java/io/reflectoring/coderadar/graph/query/repository/MetricQueryRepository.java
@@ -70,35 +70,6 @@ public interface MetricQueryRepository extends Neo4jRepository<MetricValueEntity
   List<String> getAvailableMetricsInProject(long projectId);
 
   /**
-   * Metrics for each file are collected as string in the following format: "metricName=value" The
-   * string is then split in the adapter. This greatly reduces HashMap usage. File paths are
-   * returned along with their corresponding git hashes in the following format:
-   * "filePath=ObjectHash".
-   *
-   * <p>NOTE: uses APOC.
-   *
-   * @param projectId The project id.
-   * @param commitHash The hash of the commit.
-   * @param metricNames The names of the metrics needed.
-   * @return Metrics for each file in the given commit.
-   */
-  @Query(
-      "MATCH (p)-[:CONTAINS_COMMIT]->(c:CommitEntity) WHERE ID(p) = {0} AND c.name = {1} WITH c LIMIT 1 "
-          + "CALL apoc.path.subgraphNodes(c, {relationshipFilter:'IS_CHILD_OF>'}) YIELD node WITH node as c ORDER BY c.timestamp DESC WITH collect(c) as commits "
-          + "CALL apoc.cypher.run('UNWIND commits as c OPTIONAL MATCH (f)<-[:RENAMED_FROM]-()-[:CHANGED_IN]->(c) RETURN collect(f) as renames', {commits: commits}) "
-          + "YIELD value WITH commits, value.renames as renames "
-          + "CALL apoc.cypher.run('UNWIND commits as c OPTIONAL MATCH (f)-[:CHANGED_IN {changeType: \"DELETE\"}]->(c) "
-          + "RETURN collect(f) as deletes', {commits: commits}) YIELD value WITH commits, renames, value.deletes as deletes "
-          + "UNWIND commits as c "
-          + "MATCH (f)-[:MEASURED_BY]->(m)-[:VALID_FOR]->(c) WHERE "
-          + "NOT(f IN deletes OR f IN renames) AND m.name IN {2} WITH f.path as path, head(collect(f.objectHash)) as hash, m.name as name, "
-          + "head(collect(m.value)) as value ORDER BY path, name WHERE value <> 0 "
-          + "RETURN path + \"=\" + head(collect(hash)) as path, collect(name + \"=\" + value) as metrics ORDER BY path")
-  @NonNull
-  List<Map<String, Object>> getMetricTreeForCommitWithFileHashes(
-      long projectId, @NonNull String commitHash, @NonNull List<String> metricNames);
-
-  /**
    * NOTE: This query is currently unused, but I believe it might be useful in the future.
    *
    * @param projectId The project id.

--- a/coderadar-vcs/src/main/java/io/reflectoring/coderadar/vcs/adapter/ExtractProjectCommitsAdapter.java
+++ b/coderadar-vcs/src/main/java/io/reflectoring/coderadar/vcs/adapter/ExtractProjectCommitsAdapter.java
@@ -107,7 +107,6 @@ public class ExtractProjectCommitsAdapter implements ExtractProjectCommitsPort {
         File file = new File();
         file.setSequenceId(sequenceId++);
         file.setPath(treeWalk.getPathString());
-        file.setObjectHash(treeWalk.getObjectId(0).getName());
 
         FileToCommitRelationship fileToCommitRelationship = new FileToCommitRelationship();
         fileToCommitRelationship.setOldPath("/dev/null");
@@ -202,7 +201,6 @@ public class ExtractProjectCommitsAdapter implements ExtractProjectCommitsPort {
     List<File> filesToSave;
     File file = new File();
     file.setSequenceId(sequenceId);
-    file.setObjectHash(diff.getNewId().name());
     file.setPath(path);
     if (existingFilesWithPath == null) {
       if ((diff.getChangeType().equals(DiffEntry.ChangeType.RENAME))) {
@@ -217,17 +215,9 @@ public class ExtractProjectCommitsAdapter implements ExtractProjectCommitsPort {
     } else {
       if ((diff.getChangeType().equals(DiffEntry.ChangeType.ADD))) {
         filesToSave = new ArrayList<>(1);
-        Optional<File> existingWithSameHash =
-            existingFilesWithPath.stream()
-                .filter(file1 -> file1.getObjectHash().equals(file.getObjectHash()))
-                .findFirst();
-        if (existingWithSameHash.isPresent()) {
-          filesToSave.add(existingWithSameHash.get());
-        } else {
-          filesToSave.add(file);
-          existingFilesWithPath.add(file);
-          files.put(file.getPath(), existingFilesWithPath);
-        }
+        filesToSave.add(file);
+        existingFilesWithPath.add(file);
+        files.put(file.getPath(), existingFilesWithPath);
       } else if ((diff.getChangeType().equals(DiffEntry.ChangeType.DELETE))) {
         filesToSave = new ArrayList<>(existingFilesWithPath);
       } else if ((diff.getChangeType().equals(DiffEntry.ChangeType.RENAME))) {

--- a/coderadar-vcs/src/main/java/io/reflectoring/coderadar/vcs/adapter/GetRawCommitContentAdapter.java
+++ b/coderadar-vcs/src/main/java/io/reflectoring/coderadar/vcs/adapter/GetRawCommitContentAdapter.java
@@ -38,7 +38,7 @@ public class GetRawCommitContentAdapter implements GetRawCommitContentPort {
     }
   }
 
-  public List<Pair<String, String>> findRenames(
+  public List<Pair<String, String>> getRenamesBetweenCommits(
       String parentHash, String commitHash, String projectRoot) {
     ObjectId commitId = ObjectId.fromString(commitHash);
     ObjectId parentId = ObjectId.fromString(parentHash);

--- a/coderadar-vcs/src/main/java/io/reflectoring/coderadar/vcs/adapter/GetRawCommitContentAdapter.java
+++ b/coderadar-vcs/src/main/java/io/reflectoring/coderadar/vcs/adapter/GetRawCommitContentAdapter.java
@@ -9,8 +9,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
-import org.apache.commons.lang3.tuple.ImmutablePair;
-import org.apache.commons.lang3.tuple.Pair;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.diff.*;
 import org.eclipse.jgit.lib.ObjectId;
@@ -19,6 +17,7 @@ import org.eclipse.jgit.revwalk.RevWalk;
 import org.eclipse.jgit.treewalk.TreeWalk;
 import org.eclipse.jgit.treewalk.filter.TreeFilter;
 import org.gitective.core.BlobUtils;
+import org.springframework.data.util.Pair;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -38,6 +37,7 @@ public class GetRawCommitContentAdapter implements GetRawCommitContentPort {
     }
   }
 
+  @Override
   public List<Pair<String, String>> getRenamesBetweenCommits(
       String parentHash, String commitHash, String projectRoot) {
     ObjectId commitId = ObjectId.fromString(commitHash);
@@ -62,7 +62,7 @@ public class GetRawCommitContentAdapter implements GetRawCommitContentPort {
         renameDetector.addAll(DiffEntry.scan(treeWalk));
         for (DiffEntry ent : renameDetector.compute()) {
           if (ent.getChangeType() == DiffEntry.ChangeType.RENAME)
-            result.add(new ImmutablePair<>(ent.getOldPath(), ent.getNewPath()));
+            result.add(Pair.of(ent.getOldPath(), ent.getNewPath()));
         }
       }
     } catch (IOException e) {

--- a/coderadar-vcs/src/main/java/io/reflectoring/coderadar/vcs/adapter/GetRawCommitContentAdapter.java
+++ b/coderadar-vcs/src/main/java/io/reflectoring/coderadar/vcs/adapter/GetRawCommitContentAdapter.java
@@ -5,17 +5,19 @@ import io.reflectoring.coderadar.vcs.UnableToGetCommitContentException;
 import io.reflectoring.coderadar.vcs.port.driven.GetRawCommitContentPort;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.Pair;
 import org.eclipse.jgit.api.Git;
-import org.eclipse.jgit.diff.DiffFormatter;
-import org.eclipse.jgit.diff.HistogramDiff;
-import org.eclipse.jgit.diff.RawText;
-import org.eclipse.jgit.diff.RawTextComparator;
+import org.eclipse.jgit.diff.*;
 import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.revwalk.RevCommit;
 import org.eclipse.jgit.revwalk.RevWalk;
+import org.eclipse.jgit.treewalk.TreeWalk;
+import org.eclipse.jgit.treewalk.filter.TreeFilter;
 import org.gitective.core.BlobUtils;
 import org.springframework.stereotype.Service;
 
@@ -36,6 +38,39 @@ public class GetRawCommitContentAdapter implements GetRawCommitContentPort {
     }
   }
 
+  public List<Pair<String, String>> findRenames(
+      String parentHash, String commitHash, String projectRoot) {
+    ObjectId commitId = ObjectId.fromString(commitHash);
+    ObjectId parentId = ObjectId.fromString(parentHash);
+    RevCommit commit;
+    RevCommit parent;
+
+    List<Pair<String, String>> result = new ArrayList<>();
+    try (Git git = Git.open(new java.io.File(projectRoot))) {
+      try (RevWalk revWalk = new RevWalk(git.getRepository())) {
+        commit = revWalk.parseCommit(commitId);
+        parent = revWalk.parseCommit(parentId);
+      }
+
+      RenameDetector renameDetector = new RenameDetector(git.getRepository());
+
+      try (TreeWalk treeWalk = new TreeWalk(git.getRepository())) {
+        treeWalk.setFilter(TreeFilter.ANY_DIFF);
+        treeWalk.setRecursive(true);
+        treeWalk.reset(parent.getTree(), commit.getTree());
+        renameDetector.reset();
+        renameDetector.addAll(DiffEntry.scan(treeWalk));
+        for (DiffEntry ent : renameDetector.compute()) {
+          if (ent.getChangeType() == DiffEntry.ChangeType.RENAME)
+            result.add(new ImmutablePair<>(ent.getOldPath(), ent.getNewPath()));
+        }
+      }
+    } catch (IOException e) {
+      throw new UnableToGetCommitContentException(e.getMessage());
+    }
+    return result;
+  }
+
   @Override
   public byte[] getFileDiff(String projectRoot, String filepath, String commitHash)
       throws UnableToGetCommitContentException {
@@ -43,6 +78,7 @@ public class GetRawCommitContentAdapter implements GetRawCommitContentPort {
       return new byte[0];
     }
     try (Git git = Git.open(new java.io.File(projectRoot))) {
+
       ObjectId commitId = ObjectId.fromString(commitHash);
       RevCommit commit;
       try (RevWalk revWalk = new RevWalk(git.getRepository())) {


### PR DESCRIPTION
The delta tree endpoint does not properly recognize all renames. 
Currently a rename is recognized only if a file was renamed without any changes to it since it was added.
This could partly be fixed by setting the `objectHash` attribute on the relationship between a file and a commit instead of on the file node. However, that still woudn't be perfect as sometimes file contents change between renames. Internally git uses algorithms and has specific thresholds for detecting how much of a file has changed and then deciding if the change can still be labeled a rename. In this PR I just use JGit to get all renames between two arbitrary commits. This simplifies the adapter and also makes the query faster.